### PR TITLE
feat(envsubstTemplate): add envsubstTemplate option

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,28 @@ export default {
 };
 ```
 
+#### envsubstTemplate
+
+Specifies whether to create an envsubst template file at build time. Defaults to `false`.
+
+```ts
+envsubstTemplate?: boolean
+```
+
+```ts
+runtimeEnv({
+  envsubstTemplate: true,
+}),
+```
+
+When `true` the plugin will create the following template file:
+
+```js
+export default {
+  APP_KEY: $APP_KEY,
+};
+```
+
 ## runtimeHtml
 
 ### Summary

--- a/src/runtime.env.config.ts
+++ b/src/runtime.env.config.ts
@@ -22,4 +22,9 @@ export type RuntimeEnvConfig = {
    * @default true
    */
   injectHtml?: boolean;
+  /**
+   * Specifies whether to create an envsubst template file at build time
+   * @default false
+   */
+  envsubstTemplate?: boolean;
 };

--- a/src/runtime.env.ts
+++ b/src/runtime.env.ts
@@ -129,10 +129,14 @@ export const runtimeEnv = (options: RuntimeEnvConfig = { injectHtml: true }): Pl
       const globalName = getName(runtimeEnvConfig);
 
       const jsonObj: Record<string, unknown> = {};
+      const envsubstTemplateObj: Record<string, string> = {};
 
       Object.entries(envObj).forEach(entry => {
         const entryType = getType(entry[1]);
         jsonObj[entry[0]] = entryType === 'number' ? Number(entry[1]) : entryType === 'boolean' ? Boolean(entry[1]) : entry[1];
+        if (runtimeEnvConfig.envsubstTemplate === true) {
+          envsubstTemplateObj[entry[0]] = `$${entry[0]}`;
+        }
       });
 
       const output = `export default ${JSON.stringify(jsonObj)} ;`;
@@ -142,6 +146,16 @@ export const runtimeEnv = (options: RuntimeEnvConfig = { injectHtml: true }): Pl
         fileName: `${globalName}.js`,
         source: output,
       });
+
+      if (runtimeEnvConfig.envsubstTemplate === true) {
+        const envsubstTemplateOutput = `export default ${JSON.stringify(envsubstTemplateObj)} ;`;
+
+        this.emitFile({
+          type: 'asset',
+          fileName: `${globalName}.template.js`,
+          source: envsubstTemplateOutput,
+        });
+      }
     },
   };
 };


### PR DESCRIPTION
Hello,

first, thanks for this plugin, it fits nearly all my needs, except for what this PR is about to propose. This is my first time contributing to open source, so feel free to tell me if I'm doing anything wrong.

### Purpose of this PR

In a context where you want to use `envsubst` just before running your nginx server to replace environment variables, the plugin was lacking something. So I introduced a new `envsubstTemplate` option, which generates a `env.template.js` file at build time, which will be compatible with `envsubst` afterwards.

### Usage of the `env.template.js` file

```bash
envsubst < env.template.js > env.js
```

Open for feedbacks :)

Thanks